### PR TITLE
Allow ExternalAuthentication with a host

### DIFF
--- a/exampleSql_test.go
+++ b/exampleSql_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/mattn/go-oci8"
+	"github.com/heymian/go-oci8"
 )
 
 func Example_sqlSelect() {

--- a/oci8.go
+++ b/oci8.go
@@ -122,7 +122,7 @@ func ParseDSN(dsnString string) (dsn *DSN, err error) {
 		}
 	}
 
-	if len(dsn.Username)+len(dsn.Password)+len(dsn.Connect) == 0 {
+	if len(dsn.Username)+len(dsn.Password) == 0 {
 		dsn.externalauthentication = true
 	}
 	return dsn, nil
@@ -276,7 +276,7 @@ func (oci8Driver *OCI8DriverStruct) Open(dsnString string) (driver.Conn, error) 
 		}
 		conn.srv = (*C.OCIServer)(*handle)
 
-		if dsn.externalauthentication {
+		if len(dsn.Connect) == 0 {
 			result = C.OCIServerAttach(
 				conn.srv,       // uninitialized server handle, which gets initialized by this call. Passing in an initialized server handle causes an error.
 				conn.errHandle, // error handle


### PR DESCRIPTION
When attempting to get connections to work with Kerberos, we have a host but no username/password. It seems that even when using ExternalAuthentication, you should still be able to specify a host, so checking the dns.Connect string seems like a better way to determine which path to take. 